### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ The demo project also includes a UITableView that automatically loads the next p
 
 ## How to install
 
-### With Cocoapods
+### With CocoaPods
 
 Add this to your Podfile:
 ```
 pod 'NMPaginator', '~> 1.0.0'
 ```
 
-For more information on how to set up Cocoapods, check out the [official site](http://cocoapods.org/#get_started).
+For more information on how to set up CocoaPods, check out the [official site](http://cocoapods.org/#get_started).
 
 ### Manually
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
